### PR TITLE
Got rid of projective coordinates.

### DIFF
--- a/render/headers/render.h
+++ b/render/headers/render.h
@@ -68,12 +68,6 @@ Material;
 typedef 
 struct {
 	void * data;
-        
-	void (*rotate)(void * data,
-                   const Float sin_al,
-                   const Float cos_al,
-                   const Float sin_be,
-                   const Float cos_be);
     
 	Boolean (*intersect)(const void * data,
                          const Point3d vector_start,
@@ -146,6 +140,10 @@ struct {
     // Angles of projection
     Float al;
     Float be;
+    Float sin_be;
+    Float cos_be;
+    Float sin_al;
+    Float cos_al;
     
     // Array of pointers to 3d objects of scene
     Object3d ** objects;

--- a/render/headers/utils.h
+++ b/render/headers/utils.h
@@ -40,10 +40,23 @@ rotate_point(const Point3d p,
              const Float sin_be,
              const Float cos_be) {
     
-	Float x = p.x * cos_al - p.y * sin_al;
-	Float y = p.x * sin_al * cos_be + p.y * cos_al * cos_be - p.z * sin_be;
-	Float z = p.x * sin_al * sin_be + p.y * cos_al * sin_be + p.z * cos_be;
+	Float z = p.z * cos_al - p.y * sin_al;
+	Float y = p.z * sin_al * cos_be + p.y * cos_al * cos_be - p.x * sin_be;
+	Float x = p.z * sin_al * sin_be + p.y * cos_al * sin_be + p.x * cos_be;
 	return point3d(x, y, z);
+}
+
+static inline Vector3d
+rotate_vector(const Vector3d v,
+             const Float sin_al,
+             const Float cos_al,
+             const Float sin_be,
+             const Float cos_be) {
+    
+	Float z = v.z * cos_al - v.y * sin_al;
+	Float y = v.z * sin_al * cos_be + v.y * cos_al * cos_be - v.x * sin_be;
+	Float x = v.z * sin_al * sin_be + v.y * cos_al * sin_be + v.x * cos_be;
+	return vector3df(x, y, z);
 }
 
 #endif

--- a/render/headers/utils.h
+++ b/render/headers/utils.h
@@ -39,10 +39,11 @@ rotate_point(const Point3d p,
              const Float cos_al,
              const Float sin_be,
              const Float cos_be) {
-    
-	Float z = p.z * cos_al - p.y * sin_al;
-	Float y = p.z * sin_al * cos_be + p.y * cos_al * cos_be - p.x * sin_be;
+
 	Float x = p.z * sin_al * sin_be + p.y * cos_al * sin_be + p.x * cos_be;
+	Float y = p.z * sin_al * cos_be + p.y * cos_al * cos_be - p.x * sin_be;
+	Float z = p.z * cos_al - p.y * sin_al;
+    
 	return point3d(x, y, z);
 }
 
@@ -53,9 +54,11 @@ rotate_vector(const Vector3d v,
              const Float sin_be,
              const Float cos_be) {
     
-	Float z = v.z * cos_al - v.y * sin_al;
+
+    Float x = v.z * sin_al * sin_be + v.y * cos_al * sin_be + v.x * cos_be;
 	Float y = v.z * sin_al * cos_be + v.y * cos_al * cos_be - v.x * sin_be;
-	Float x = v.z * sin_al * sin_be + v.y * cos_al * sin_be + v.x * cos_be;
+	Float z = v.z * cos_al - v.y * sin_al;
+    
 	return vector3df(x, y, z);
 }
 

--- a/render/source/render.c
+++ b/render/source/render.c
@@ -54,9 +54,12 @@ void trace(Scene * scene,
            Vector3d vector,
            Color * color) {
     
+    Point3d r_vector_start = rotate_point(vector_start, scene->sin_al, scene->cos_al, scene->sin_be, scene->cos_be);
+    Vector3d r_vector = rotate_vector(vector, scene->sin_al, scene->cos_al, scene->sin_be, scene->cos_be);
+    
     trace_recursively(scene,
-                      vector_start,
-                      vector,
+                      r_vector_start,
+                      r_vector,
                       color,
                       INITIAL_RAY_INTENSITY,
                       0);

--- a/render/source/scene.c
+++ b/render/source/scene.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include <float.h>
 #include <math.h>
 
@@ -81,6 +82,21 @@ rotate_scene(Scene * const scene,
     scene->cos_be = cos(scene->al);
     scene->sin_al = sin(scene->be);
     scene->cos_al = cos(scene->be);
+    
+    int i;
+    LightSource3d * light;
+    if(!rotate_light_sources) {
+        for(i = 0; i < scene->light_sources_count; i++) {
+            if(scene->light_sources[i]) {
+                light = scene->light_sources[i];
+                light->location = rotate_point(light->location_world,
+                                               scene->sin_al,
+                                               scene->cos_al,
+                                               scene->sin_be,
+                                               scene->cos_be);
+            }
+        }
+    }
 }
 
 void


### PR DESCRIPTION
When rotating scene - just transform camera coordinates into world coordinates. It helps to avoid rebuild of kd-tree after each rotation of scene.
